### PR TITLE
Restartwinrm syntax fix

### DIFF
--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -128,9 +128,8 @@ module Kitchen
       #private
 
       def restart_winrm_service
-
-        cmd = 'schtasks /Create /TN restart_winrm /TR ' /
-              '"powershell -command restart-service winrm" ' /
+        cmd = 'schtasks /Create /TN restart_winrm /TR ' \
+              '"powershell -command restart-service winrm" ' \
               '/SC ONCE /ST 00:00 '
         wrap_shell_code(Util.outdent!(<<-CMD
           #{cmd}

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -128,11 +128,8 @@ module Kitchen
       #private
 
       def restart_winrm_service
-        cmd = 'schtasks /Create /TN restart_winrm /TR ' \
-              '"powershell -command restart-service winrm" ' \
-              '/SC ONCE /ST 00:00 '
         wrap_shell_code(Util.outdent!(<<-CMD
-          #{cmd}
+          schtasks /Create /TN restart_winrm /TR "powershell -command restart-service winrm" /SC ONCE /ST 00:00
           schtasks /RUN /TN restart_winrm
         CMD
         ))


### PR DESCRIPTION
This addresses issue #9  where the forward slashes ( `/` ) cause an "undefined method" exception. This bug was introduced in this [revision](https://github.com/test-kitchen/kitchen-pester/commit/ca9e3bc1f0b3e5da18b341bdebaf887359e7b92d). All I did was revert the restart_winrm_service method to what is was in version 0.3.0. 