### PR TITLE
Ensure NuGet package provider is bootstrapped before use

### DIFF
--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -77,6 +77,8 @@ module Kitchen
           if (-not (get-module -list pester)) {
             if (get-module -list PowerShellGet){
               import-module PowerShellGet -force
+              import-module PackageManagement -force
+              get-packageprovider -name NuGet -force
               install-module Pester -force
             }
             else {

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -78,7 +78,7 @@ module Kitchen
             if (get-module -list PowerShellGet){
               import-module PowerShellGet -force
               import-module PackageManagement -force
-              get-packageprovider -name NuGet -force
+              get-packageprovider -name NuGet -force | out-null
               install-module Pester -force
             }
             else {


### PR DESCRIPTION
When WMF5 is freshly installed, the first time `Install-Module` tries to download a package it will prompt the user to download `NuGet-anycpu.exe`. The `-Force` parameter does not bypass this prompt which
results in Kitchen appearing to hang during the Verify step.

Running `Get-PackageProvider` will not cause NuGet to be downloaded again if it is already found on the system.

(This is a properly-done version of #14, because string escaping is hard.)