### PR TITLE
Include Helpers/ Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ This can be a top-level declaration, a per-node declaration, or a per-suite decl
 
 * `restart_winrm` - boolean, default is false.  This is primarily to support powershell v2 scenarios.  If Pester is not being found, enable this option.
 * `test_folder` - string, default is nil.  `test-folder` allows you to specify a custom path (the default is ./test/integration/) for your integration tests.  This can be an absolute path or relative to the root of the folder kitchen is running from.  This path must exist.
-* `copy_helpers` - boolean, default is false. This will copy the contents of ./test/integration/helpers/ which can be helpful for shared tests. 
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This can be a top-level declaration, a per-node declaration, or a per-suite decl
 
 * `restart_winrm` - boolean, default is false.  This is primarily to support powershell v2 scenarios.  If Pester is not being found, enable this option.
 * `test_folder` - string, default is nil.  `test-folder` allows you to specify a custom path (the default is ./test/integration/) for your integration tests.  This can be an absolute path or relative to the root of the folder kitchen is running from.  This path must exist.
+* `copy_helpers` - boolean, default is false. This will copy the contents of ./test/integration/helpers/ which can be helpful for shared tests. 
 
 ## Contributing
 

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -34,7 +34,6 @@ module Kitchen
       default_config :test_folder
       default_config :run_as_scheduled_task, false
       default_config :use_local_pester_module, false
-      default_config :copy_helpers, false
 
       # Creates a new Verifier object using the provided configuration data
       # which will be merged with any default configuration.
@@ -66,7 +65,7 @@ module Kitchen
         super
         prepare_powershell_modules
         prepare_pester_tests
-        prepare_helpers if config[:copy_helpers]
+        prepare_helpers
       end
 
       # Generates a command string which will install and configure the


### PR DESCRIPTION
As mentioned in Issue #20 - The busser plugin allows for a "helpers" directory to be transferred over to the remote node. This directory can be used to hold shared spec_helpers or shared tests. 

This works for me really well... I'm able to define a shared set of tests to run over all my test-kitchen suites by including a .tests.ps1 file in ./test/integration/helpers/pester directory. Not sure if we want to limit the selection to only *.Tests.ps1 in the `prepare_helpers` function. Left it off for now to mock the current busser logic. 

I've hidden this behind a config option (`copy_helpers`) which defaults to false so that current functionality is neither changed or broken. I've included the new option in the README. That can be left off until this change stabilizes.

Please let me know what you think, if any changes or improvements are needed, I'll get those in right away! 