### PR TITLE
Ignore case of navigated path

### DIFF
--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -258,7 +258,7 @@ module Kitchen
       end
 
       def sandboxify_path(path)
-        File.join(sandbox_path, path.sub("#{suite_test_folder}/", ""))
+        File.join(sandbox_path, path.sub(/#{suite_test_folder}\//i, ""))
       end
 
       # Returns an Array of common helper filenames currently residing on the

--- a/spec/pester/pester_spec.rb
+++ b/spec/pester/pester_spec.rb
@@ -1,0 +1,21 @@
+require_relative '..\..\lib\kitchen\verifier\Pester'
+
+class MockPester < Kitchen::Verifier::Pester
+    def sandbox_path
+        'C:/users/jdoe/temp/kitchen-temp'
+    end
+    def suite_test_folder
+        'C:/lowercasedpath/Pester/tests'
+    end
+end
+
+describe 'when sandboxifying a path' do
+    let(:sandboxifiedPath) {
+        pester = MockPester.new
+        pester.sandboxify_path('C:/LOWERcasedpath/Pester/tests/test')
+    }
+
+    it 'should ignore case' do
+        expect(sandboxifiedPath).to eq 'C:/users/jdoe/temp/kitchen-temp/test'
+    end
+end


### PR DESCRIPTION
Found this bug last week where `kitchen verify `would fail if you navigated to the cookbook path in the console using different letter casing.  Fixed by adding the regex ignore directive.  Unit test also included.

Found root cause with the help of the following issue:

https://github.com/test-kitchen/test-kitchen/issues/1190