### PR TITLE
Loosen the Test Kitchen dep and shrink files shipped in the gem

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,9 @@ environment:
   KITCHEN_YAML: .kitchen.appveyor.yml
 
   matrix:
-    - ruby_version: "23"
+    - ruby_version: "24"
+    - ruby_version: "25"
+    - ruby_version: "26"
 
 branches:
   only:
@@ -30,7 +32,7 @@ install:
   - ps: Write-Host $env:PATH
   - ps: ruby --version
   - ps: gem --version
-  - ps: gem install bundler --quiet --no-ri --no-rdoc
+  - ps: gem install bundler --quiet --no-document
   - ps: bundler --version
 
 build_script:

--- a/kitchen-pester.gemspec
+++ b/kitchen-pester.gemspec
@@ -14,14 +14,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/test-kitchen/kitchen-pester"
   spec.license       = "Apache 2"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR).grep(/LICENSE|^lib/)
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 11.3"
-  spec.add_development_dependency "pry", "~> 0.10"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "pry"
 
-  spec.add_dependency "test-kitchen", "~> 1.10"
+  spec.add_dependency "test-kitchen", ">= 1.10", "< 3"
 end


### PR DESCRIPTION
Test Kitchen 2.0 has no impact on this plugin so allow it
Remove deps constraints on test deps
Only ship the files necessary to actually run this plugin

Signed-off-by: Tim Smith <tsmith@chef.io>