### PR TITLE
Improve File Download functionality

### DIFF
--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -114,8 +114,10 @@ module Kitchen
 
         info("Downloading files from #{instance.to_str}")
         config[:downloads].to_h.each do |remotes, local|
-          debug("Downloading #{Array(remotes).join(", ")} to #{local}")
-          conn.download(remotes, local)
+          instance.transport.connection(state) do |conn|
+            debug("Downloading #{Array(remotes).join(", ")} to #{local}")
+            conn.download(remotes, local)
+          end
         end
         debug("Download complete")
       end

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -33,7 +33,7 @@ module Kitchen
       default_config :restart_winrm, false
       default_config :test_folder
       default_config :use_local_pester_module, false
-      default_config :downloads, ["#{config[:root_path]}/PesterTestResults.xml"] => './testresults'
+      default_config :downloads, ["./PesterTestResults.xml"] => './testresults'
 
       # Creates a new Verifier object using the provided configuration data
       # which will be merged with any default configuration.
@@ -112,14 +112,19 @@ module Kitchen
       def call(state)
         super
 
-        info("Downloading files from #{instance.to_str}")
-        config[:downloads].to_h.each do |remotes, local|
-          instance.transport.connection(state) do |conn|
+        info("Downloading test result files from #{instance.to_str}")
+        instance.transport.connection(state) do |conn|
+          config[:downloads].to_h.each do |remotes, local|
             debug("Downloading #{Array(remotes).join(", ")} to #{local}")
-            conn.download(remotes, local)
+            remotes.each do |file|
+              local_path = File.join(local, file)
+              remote_path = File.join(config[:root_path], file)
+
+              conn.download(remote_path, local_path)
+            end
           end
         end
-        debug("Download complete")
+        debug("Finished downloading test result files from #{instance.to_str}")
       end
 
       # private

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -33,7 +33,7 @@ module Kitchen
       default_config :restart_winrm, false
       default_config :test_folder
       default_config :use_local_pester_module, false
-      default_config :downloads, ['./PesterTestResults.xml'] => './testresults'
+      default_config :downloads, ["#{config[:root_path]}/PesterTestResults.xml"] => './testresults'
 
       # Creates a new Verifier object using the provided configuration data
       # which will be merged with any default configuration.
@@ -125,12 +125,13 @@ module Kitchen
       # private
       def run_command_script
         <<-CMD
-          $TestPath = "#{config[:root_path]}";
-          import-module Pester -force;
-          $result = invoke-pester -OutputFile PesterTestResults.xml -OutputFormat NUnitXml -path $testpath -passthru ;
-          $result |
-            export-clixml (join-path $testpath 'result.xml');
-          $host.setshouldexit($result.failedcount)
+          Import-Module Pester -Force
+          $TestPath = "#{config[:root_path]}"
+          $OutputFilePath = $TestPath | Join-Path -ChildPath 'PesterTestResults.xml'
+
+          $result = Invoke-Pester -OutputFile $OutputFilePath -OutputFormat NUnitXml -Path $TestPath -Passthru
+          $result | Export-CliXml -Path (Join-Path -Path $TestPath -ChildPath 'result.xml')
+          $host.SetShouldExit($result.FailedCount)
         CMD
       end
 
@@ -142,7 +143,7 @@ module Kitchen
         <<-EOH
           set-executionpolicy unrestricted -force;
           $global:ProgressPreference = 'SilentlyContinue'
-          $env:psmodulepath += ";$(join-path (resolve-path $env:temp).path 'verifier/modules')";
+          $env:psmodulepath += ";$(join-path (resolve-path $env:temp).path 'verifier/modules')"
           #{script}
         EOH
       end


### PR DESCRIPTION
## Summary

- Fixed the error where `conn` is undefined -- looks like we missed a step where the connection actually needs to be established first.
- Ensured the files we're looking for can be found by manually constructing absolute paths rather than relying on relative paths.
- Small amount of tidying up the PowerShell code in one section for my sanity 😁 
- Test files are stored back to the local file tree under `testresults/#{instance.name}/PesterTestResults.xml` to avoid overwriting the file when multiple different test instances run in succession.
  - The file will still be overwritten if the _same_ instance is rerun.
- Pulled download functionality to a new method, hopefully this will make it easier to sidestep when the functionality is incorporated into the base class.

/cc @smurawski 