### PR TITLE
Properly handle custom downloads settings

### DIFF
--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -291,7 +291,7 @@ module Kitchen
           config[:downloads].to_h.each do |remotes, local|
             debug("Downloading #{Array(remotes).join(", ")} to #{local}")
 
-            remotes.each do |file|
+            Array(remotes).each do |file|
               safe_name = instance.name.gsub(/[^0-9A-Z-]/i, "_")
               local_path = File.join(local, safe_name, file)
               remote_path = File.join(config[:root_path], file)


### PR DESCRIPTION
Previously we were assuming the user input was of the form `{ [remotefile] => localfile }` since our default config was of that form.

That format is actually impossible to specify in yaml, so we need to ensure we're handling both scalar and array keys for our default config and user input config to work correctly.

Resolves #53 