### PR TITLE
Bind pry / pry-byebug to 0.13.x / 3.9.x to fix dependency resolution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ group :changelog do
 end
 
 group :debug do
-  gem "pry"
-  gem "pry-byebug"
+  gem "pry", "~>0.12.0"
+  gem "pry-byebug", "~3.8.0"
   gem "pry-stack_explorer"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ end
 
 group :debug do
   gem "pry", "~>0.12.0"
-  gem "pry-byebug", "~3.8.0"
+  gem "pry-byebug", "~>3.8.0"
   gem "pry-stack_explorer"
 end
 


### PR DESCRIPTION
Bind `pry` and `pry-byebug` to specific minor versions to avoid dependency resolution issue. 

Both `bundler` and our CI was timing out and taking over an hour to resolve dependencies. After tinkering with the gemfile and binding everything explicitly to recent minor versions, bundler shows the following output:

```
Bundler could not find compatible versions for gem "method_source":
  In Gemfile:
    kitchen-inspec (~> 1.3.0) was resolved to 1.3.2, which depends on
      inspec (>= 1.47, < 5.0) was resolved to 4.18.51, which depends on
        method_source (~> 0.8)

    pry-byebug (~> 3.9.0) was resolved to 3.9.0, which depends on
      pry (~> 0.13.0) was resolved to 0.13.1, which depends on
        method_source (~> 1.0)
```

It seems recent versions of `kitchen-inspec` and `pry` are causing dependency conflicts, since the latest version of `kitchen-inspec` wants an older version of `method_source` than the `pry` packages want.

Until `kitchen-inspec` is updated to work with `method_source` v1.0 at least, we can downgrade the `pry` package versions to the previous minor version to avoid the dependency resolution issue. This should fix our pipeline CI issue.