### PR TITLE
Fix downloading files on failure

### DIFF
--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -119,7 +119,7 @@ module Kitchen
           download_test_files(state)
         end
       else
-        def call (state)
+        def call(state)
           super
         rescue
           # If the verifier reports failure, we need to download the files ourselves.
@@ -313,14 +313,7 @@ module Kitchen
         instance.transport.connection(state) do |conn|
           config[:downloads].to_h.each do |remotes, local|
             debug("Downloading #{Array(remotes).join(", ")} to #{local}")
-
-            Array(remotes).each do |file|
-              safe_name = instance.name.gsub(/[^0-9A-Z-]/i, "_")
-              local_path = File.join(local, safe_name, file)
-              remote_path = File.join(config[:root_path], file)
-
-              conn.download(remote_path, local_path)
-            end
+            conn.download(remotes, local)
           end
         end
 

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -141,7 +141,7 @@ module Kitchen
 
           $options = New-PesterOption -TestSuiteName "Pester - #{instance.to_str}"
 
-          $result = Invoke-Pester -Script $TestPath -OutputFile $OutputFilePath -OutputFormat NUnitXml -PesterOption $option -PassThru
+          $result = Invoke-Pester -Script $TestPath -OutputFile $OutputFilePath -OutputFormat NUnitXml -PesterOption $options -PassThru
           $result | Export-CliXml -Path (Join-Path -Path $TestPath -ChildPath 'result.xml')
 
           $LASTEXITCODE = $result.FailedCount
@@ -236,11 +236,19 @@ module Kitchen
                           Import-Module -Name PsGet -Force -ErrorAction Stop
                       }
 
-                      Install-Module -Name Pester
+                      Install-Module -Name Pester -Force
                   }
                   catch {
                       Write-Host "Installing from Github"
-                      $zipfile = Join-Path (Get-Item -Path "$env:TEMP/module").FullName -ChildPath "pester.zip"
+
+                      $downloadFolder = if (Test-Path "$env:TEMP/PesterDownload") {
+                          "$env:TEMP/PesterDownload"
+                      }
+                      else {
+                          New-Item -ItemType Directory -Path "$env:TEMP/PesterDownload"
+                      }
+
+                      $zipFile = Join-Path (Get-Item -Path $downloadFolder).FullName -ChildPath "pester.zip"
 
                       if (-not (Test-Path $zipfile)) {
                           $source = 'https://github.com/pester/Pester/archive/4.10.1.zip'

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -115,8 +115,19 @@ module Kitchen
       if Gem::Version.new(Kitchen::VERSION) <= Gem::Version.new("2.3.4")
         def call(state)
           super
-
+        ensure
           download_test_files(state)
+        end
+      else
+        def call (state)
+          super
+        rescue
+          # If the verifier reports failure, we need to download the files ourselves.
+          # Test Kitchen's base verifier doesn't have the download in an `ensure` block.
+          download_test_files(state)
+
+          # Rethrow original exception, we still want to register the failure.
+          raise
         end
       end
 


### PR DESCRIPTION
Again, with feeling!

So it turns out test kitchen doesn't actually `ensure` that file downloads succeed, even in the most recent (2.4.0) version. I've filed https://github.com/test-kitchen/test-kitchen/issues/1643 but we can workaround the issue in the meantime with a little extra handling.

Related, we should also match the newer kitchen code with how it's handling downloads as much as possible.

There are also a couple of minor edge cases remaining in the refactored PS script, mainly cropping up in some of the fallback cases when certain folders don't already exist.