### PR TITLE
Fix path handling for suites

### DIFF
--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -136,8 +136,8 @@ module Kitchen
         <<-CMD
           Import-Module -Name Pester -Force
 
-          $TestPath = "#{config[:root_path]}"
-          $OutputFilePath = Join-Path $TestPath -ChildPath 'PesterTestResults.xml'
+          $TestPath = Join-Path "#{config[:root_path]}" -ChildPath "suites"
+          $OutputFilePath = Join-Path "#{config[:root_path]}" -ChildPath 'PesterTestResults.xml'
 
           $options = New-PesterOption -TestSuiteName "Pester - #{instance.to_str}"
 
@@ -165,7 +165,7 @@ module Kitchen
           }
 
           $global:ProgressPreference = 'SilentlyContinue'
-          $env:PSModulePath = "$(Join-Path (Get-Item -Path $env:TEMP).FullName -ChildPath 'verifier/modules');$env:PSModulePath"
+          $env:PSModulePath = "$(Join-Path "#{config[:root_path]}" -ChildPath 'modules');$env:PSModulePath"
 
           #{script}
         EOH
@@ -197,7 +197,7 @@ module Kitchen
           }
 
           $VerifierModulePath = Confirm-Directory -Path $env:TEMP/verifier/modules
-          $VerifierTestsPath = Confirm-Directory -Path $env:TEMP/verifier/pester
+          $VerifierDownloadPath = Confirm-Directory -Path $env:TEMP/verifier/pester
 
           $env:PSModulePath = "$VerifierModulePath;$PSModulePath"
 
@@ -241,14 +241,7 @@ module Kitchen
                   catch {
                       Write-Host "Installing from Github"
 
-                      $downloadFolder = if (Test-Path "$env:TEMP/PesterDownload") {
-                          "$env:TEMP/PesterDownload"
-                      }
-                      else {
-                          New-Item -ItemType Directory -Path "$env:TEMP/PesterDownload"
-                      }
-
-                      $zipFile = Join-Path (Get-Item -Path $downloadFolder).FullName -ChildPath "pester.zip"
+                      $zipFile = Join-Path (Get-Item -Path $VerifierDownloadPath).FullName -ChildPath "pester.zip"
 
                       if (-not (Test-Path $zipfile)) {
                           $source = 'https://github.com/pester/Pester/archive/4.10.1.zip'
@@ -348,7 +341,7 @@ module Kitchen
       end
 
       def sandboxify_path(path)
-        File.join(sandbox_path, path.sub(%r{#{suite_test_folder}/}i, ""))
+        File.join(sandbox_path, "suites", path.sub(%r{#{suite_test_folder}/}i, ""))
       end
 
       # Returns an Array of common helper filenames currently residing on the

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -196,8 +196,8 @@ module Kitchen
               @(Get-Module -Name $Name -ListAvailable -ErrorAction SilentlyContinue).Count -gt 0
           }
 
-          $VerifierModulePath = Confirm-Directory -Path $env:TEMP/verifier/modules
-          $VerifierDownloadPath = Confirm-Directory -Path $env:TEMP/verifier/pester
+          $VerifierModulePath = Confirm-Directory -Path (Join-Path #{config[:root_path]} -ChildPath 'modules')
+          $VerifierDownloadPath = Confirm-Directory -Path (Join-Path #{config[:root_path]} -ChildPath 'pester')
 
           $env:PSModulePath = "$VerifierModulePath;$PSModulePath"
 

--- a/spec/pester/pester_spec.rb
+++ b/spec/pester/pester_spec.rb
@@ -21,6 +21,6 @@ describe "when sandboxifying a path" do
   end
 
   it "should ignore case" do
-    _(sandboxifiedPath).must_equal "C:/users/jdoe/temp/kitchen-temp/test"
+    _(sandboxifiedPath).must_equal "C:/users/jdoe/temp/kitchen-temp/suites/test"
   end
 end


### PR DESCRIPTION
Currently, suites go directly into the main verifier sandbox folder, which means we have to target the whole folder for Pester to discover all the tests. This creates issues because the verifier is trying to put other files and folders in this root sandbox folder, which include some PowerShell modules.

This slows down Pester's startup a good bit, and can in some cases result in Pester finding its own test files in one of these other folders and running those as well (spoiler: this takes a _long time_).

Fix is to:

1. Ensure test suite files get copied to a subfolder `suites` instead of the root sandbox path
2. Target Pester at this folder.

I've also modified the handling for downloading Pester as a zip so it gets tucked away in its own folder, out of the way.

The test results XML will still be generated in the root sandbox path, though.