### PR TITLE
Optimize our requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ desc "Run all quality tasks"
 task quality: :style
 
 begin
-  require "yard"
+  require "yard" unless defined?(YARD)
   YARD::Rake::YardocTask.new
 rescue LoadError
   puts "yard is not available. (sudo) gem install yard to generate yard documentation."

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "fileutils"
-require "pathname"
+require "fileutils" unless defined?(FileUtils)
+require "pathname" unless defined?(Pathname)
 require "kitchen/util"
 require "kitchen/verifier/base"
 require "kitchen/version"
-require "base64"
+require "base64" unless defined?(Base64)
 require_relative "pester_version"
 
 module Kitchen


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>