### PR TITLE
fix/pester5

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,41 @@ Specify parameters for installing Pester before running the tests.
 The map will be splatted to the `Install-Module -Name Pester` command.
 You can use this to install the module from a private gallery, for instance.
 
+* `pester_configuration` - hash, defaults to
+  ```ruby
+  {
+    run: {
+      path: "suites/",
+      PassThru: true,
+    },
+    TestResult: {
+      Enabled: true,
+      OutputPath: "PesterTestResults.xml",
+      TestSuiteName: "",
+    },
+    Output: {
+      Verbosity: "Detailed",
+    }
+  }
+  ```
+  This object is converted to a hashtable and used to create a PesterConfiguration object in Pester v5, in turn used with invoke pester.
+  If the installed version of Pester is v4, an hashtable is used with the outputFile, script, testSuiteName, resultXmlPath and splatted to `Invoke-Pester`.
+
+* `shell` - string, default is `Nil` which makes it call PowerShell on Windows (Windows PowerShell), pwsh on other OSes.
+It will honour the `sudo` configuration property if set to true on non-windows.
+
 * `sudo` - bool, default is `false`. (non-windows only)
 Execute all PowerShell calls as sudo.
 This is necessary in certain cases, such as when `pwsh` is installed via `snap` and is only available via `sudo` unless you customise the system's configuration.
 
-* `downloads`- map[string[], string], defaults to `["./PesterTestResults.xml"] => "./testresults"`.  
-Files to download from SUT to local system, used to download the pester results locally. The key is the remote files or directories, value the directory it should be saved to.
+* `downloads`- map[string, string], defaults to `{"./PesterTestResults.xml" => "./testresults}"`.
+Files to download from SUT to local system, used to download the pester results localy. 
+The key is the remote file (relative to verifier folder or absolute), the value is the directory (ends with / or \\) it should be saved to (relative to pwd or absolute).
+  ```yaml
+  downloads:
+      PesterTestResults.xml: "./output/testResults/"
+      kitchen_cmd.ps1: "./output/testResults/"
+  ```
 
 ---
 
@@ -133,7 +162,7 @@ verifier:
 ### Default Azure Ubuntu 18.04 Install
 
 Assuming you are using the AzureRM driver and a Ubuntu image, you may need to install pwsh before being able to execute any PowerShell code.  
-One way to achieve this is by using Test-Kitchen's lifecycle hooks to install is using the [snap](https://snapcraft.io/powershell) package management.
+One way to achieve this is by using Test-Kitchen's lifecycle hooks to install it using the [snap](https://snapcraft.io/powershell) package management.
 
 Then if your tests are written for Pester v4.x, make sure you specify a maximum version in the install.  
 As pwsh comes with a recent version of PowerShellGet, it is not necessary to bootstrap the PowerShell environment.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,20 @@ You can use this to install the module from a private gallery, for instance.
     }
   }
   ```
-  This object is converted to a hashtable and used to create a PesterConfiguration object in Pester v5, in turn used with invoke pester.
-  If the installed version of Pester is v4, an hashtable is used with the outputFile, script, testSuiteName, resultXmlPath and splatted to `Invoke-Pester`.
+
+  This object is converted to a hashtable used to create a PesterConfiguration object in **Pester v5** (`$PesterConfig = New-PesterConfiguration -Hashtable $pester_configuration`), in turn used with invoke pester (`Invoke-Pester -Configuration $PesterConfig`).  
+  If some of the following **keys** are missing, the associated defaults below will be used:
+  - **Run.Path** = `$Env:Temp/verifier/suites`
+  - **TestResult.TestSuiteName** = `Pester - $KitchenInstanceName`
+  - **TestResult.OutputPath** = `$Env:Temp/verifier/PesterTestResults.xml`
+
+  If the installed version of Pester is **v4**, and the `pester_configuration` hash is provided, valid parameters for `Invoke-Pester` will be used (and invalid parameter names will be ignored).  
+  In the case of Pester v4, and the `pester_configuration` hash does not provide the keys for `Script`,`OutputFile`,`OutputFormat`, `Passthru`, `PesterOption`, the defaults will be:
+  - Script: `$Env:Temp/verifier/suites`
+  - OutPutFile: `$Env:Temp/verifier/PesterTestResults.xml`
+  - OutputFormat: `NUnitXml`
+  - Passthru: `true`
+  - PesterOption: the result of `$(New-PesterOption -TestSuiteName "Pester - $KitchenInstanceName)`
 
 * `shell` - string, default is `Nil` which makes it call PowerShell on Windows (Windows PowerShell), pwsh on other OSes.
 It will honour the `sudo` configuration property if set to true on non-windows.

--- a/build.windows.ps1
+++ b/build.windows.ps1
@@ -1,14 +1,23 @@
+param (
+    [Parameter()]
+    [String[]]
+    $FilesAndFoldersToClean = @(
+        '~/appdata/local/chefdk/gem/ruby/*/cache/kitchen-pester-*.gem'
+        '~/appdata/local/chefdk/gem/ruby/*/specifications/kitchen-dsc-*.gemspec'
+        '~/appdata/local/chefdk/gem/ruby/*/gems/kitchen-pester-*'
+        'C:\tools\ruby30\lib\ruby\gems\*\cache\kitchen-pester-*.gem'
+        'C:\tools\ruby30\lib\ruby\gems\*\gems\kitchen-pester-*'
+        'C:\tools\ruby30\lib\ruby\gems\*\specifications\kitchen-pester-*.gemspec'
+    )
+)
 #! 
 # https://www.sitepoint.com/creating-your-first-gem/
 gem build $PSScriptRoot/kitchen-pester.gemspec
 
-rm -EA SilentlyContinue -Force ~/appdata/local/chefdk/gem/ruby/*/cache/kitchen-pester-*.gem
-rm -EA SilentlyContinue -Force ~/appdata/local/chefdk/gem/ruby/*/specifications/kitchen-dsc-*.gemspec
-rm -EA SilentlyContinue -Force ~/appdata/local/chefdk/gem/ruby/*/gems/kitchen-pester-* -Recurse
+$FilesAndFoldersToClean | ForEach-Object -Process {
+    Remove-Item -ErrorAction SilentlyContinue -Force -Recurse -Path $_
+}
 
-rm -EA SilentlyContinue -Force C:\tools\ruby30\lib\ruby\gems\*\cache\kitchen-pester-*.gem
-rm -EA SilentlyContinue -Force C:\tools\ruby30\lib\ruby\gems\*\gems\kitchen-pester- -Recurse
-rm -EA SilentlyContinue -Force C:\tools\ruby30\lib\ruby\gems\*\specifications\kitchen-pester-*.gemspec
 
 Get-Date
-gem install (gi $PSScriptRoot/kitchen-pester-*.gem).Name
+gem install (Get-Item -Path $PSScriptRoot/kitchen-pester-*.gem).Name

--- a/build.windows.ps1
+++ b/build.windows.ps1
@@ -1,10 +1,14 @@
 #! 
 # https://www.sitepoint.com/creating-your-first-gem/
-chef gem build $PSScriptRoot/kitchen-pester.gemspec
+gem build $PSScriptRoot/kitchen-pester.gemspec
 
-rm -Force ~/appdata/local/chefdk/gem/ruby/*/cache/kitchen-pester-*.gem
-rm -Force ~/appdata/local/chefdk/gem/ruby/*/specifications/kitchen-dsc-*.gemspec
-rm -Force ~/appdata/local/chefdk/gem/ruby/*/gems/kitchen-pester-* -Recurse
+rm -EA SilentlyContinue -Force ~/appdata/local/chefdk/gem/ruby/*/cache/kitchen-pester-*.gem
+rm -EA SilentlyContinue -Force ~/appdata/local/chefdk/gem/ruby/*/specifications/kitchen-dsc-*.gemspec
+rm -EA SilentlyContinue -Force ~/appdata/local/chefdk/gem/ruby/*/gems/kitchen-pester-* -Recurse
 
-chef gem install (gi $PSScriptRoot/kitchen-pester-*.gem).Name
+rm -EA SilentlyContinue -Force C:\tools\ruby30\lib\ruby\gems\*\cache\kitchen-pester-*.gem
+rm -EA SilentlyContinue -Force C:\tools\ruby30\lib\ruby\gems\*\gems\kitchen-pester- -Recurse
+rm -EA SilentlyContinue -Force C:\tools\ruby30\lib\ruby\gems\*\specifications\kitchen-pester-*.gemspec
+
 Get-Date
+gem install (gi $PSScriptRoot/kitchen-pester-*.gem).Name

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -301,7 +301,7 @@ module Kitchen
             $PesterConfig = New-PesterConfiguration -Hashtable $pesterConfigHash
             $result = Invoke-Pester -Configuration $PesterConfig
           }
-          
+        
           $resultXmlPath = (Join-Path -Path $TestPath -ChildPath 'result.xml')
           if (Test-Path -Path $resultXmlPath) {
             $result | Export-CliXml -Path
@@ -453,7 +453,6 @@ module Kitchen
       # Writing the command to a ps1 file, adding the pwsh shebang
       # invoke the file
       def really_wrap_posix_shell_code(code)
-
         my_command = <<-BASH
           echo "Running as '$(whoami)'"
           # create the modules folder, making sure it's done as current user (not root)
@@ -520,7 +519,7 @@ module Kitchen
         CMD
                                      ))
       end
-      
+
       def download_test_files(state)
         if config[:downloads].nil?
           info("Skipped downloading test result file from #{instance.to_str}; 'downloads' hash is empty.")
@@ -530,7 +529,7 @@ module Kitchen
         info("Downloading test result files from #{instance.to_str}")
         instance.transport.connection(state) do |conn|
           config[:downloads].each do |remotes, local|
-            degug("downloading #{Array(remotes).join(', ')} to #{local}")
+            degug("downloading #{Array(remotes).join(", ")} to #{local}")
             conn.download(remotes, local)
           end
         end

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -301,7 +301,7 @@ module Kitchen
             $PesterConfig = New-PesterConfiguration -Hashtable $pesterConfigHash
             $result = Invoke-Pester -Configuration $PesterConfig
           }
-        
+
           $resultXmlPath = (Join-Path -Path $TestPath -ChildPath 'result.xml')
           if (Test-Path -Path $resultXmlPath) {
             $result | Export-CliXml -Path

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -59,10 +59,10 @@ module Kitchen
         },
         Output: {
           Verbosity: "Detailed",
-        }
+        },
       }
       default_config :install_modules, []
-      default_config :downloads, {"./PesterTestResults.xml" => "./testresults/"}
+      default_config :downloads, { "./PesterTestResults.xml" => "./testresults/" }
       default_config :copy_folders, []
       default_config :sudo, false
       default_config :shell, nil
@@ -178,25 +178,24 @@ module Kitchen
         really_wrap_shell_code(invoke_pester_scriptblock)
       end
 
-      # Resolves the remote Downloads path from the verifier root path, 
+      # Resolves the remote Downloads path from the verifier root path,
       # unless they're absolute path (starts with / or C:\)
       # This updates the config[:downloads], nothing (nil) is returned.
       #
       # @return [nil] updates config downloads
       def resolve_downloads_paths!
         info("Resolving Downloads path from config.")
-        
         config[:downloads] = config[:downloads]
           .map do |source, destination|
             source = source.to_s
             info("  resolving remote source's absolute path.")
-            if !source.match?('^/|^[a-zA-Z]:[\\/]') # is Absolute?
+            unless source.match?('^/|^[a-zA-Z]:[\\/]') # is Absolute?
               info("  '#{source}' is a relative path, resolving to: #{File.join(config[:root_path], source)}")
               source = File.join(config[:root_path], source.to_s).to_s
             end
 
             if destination.match?('\\$|/$') # is Folder (ends with / or \)
-              destination = File.join(destination, File.basename(source)).to_s 
+              destination = File.join(destination, File.basename(source)).to_s
             end
             info("  Destination: #{destination}")
             if !File.directory?(File.dirname(destination))
@@ -205,10 +204,7 @@ module Kitchen
               info("  Directory #{File.dirname(destination)} seem to exist.")
             end
 
-            [
-              source,
-              destination
-            ]
+            [ source, destination ]
           end
         nil # make sure we do not return anything
       end
@@ -221,7 +217,7 @@ module Kitchen
         ensure
           info("Ensure download test files.")
           download_test_files(state) unless config[:downloads].nil?
-          info('Download complete.')
+          info("Download complete.")
         end
       else
         def call(state)
@@ -308,7 +304,7 @@ module Kitchen
           
           $resultXmlPath = (Join-Path -Path $TestPath -ChildPath 'result.xml')
           if (Test-Path -Path $resultXmlPath) {
-            $result | Export-CliXml -Path 
+            $result | Export-CliXml -Path
           }
 
           $LASTEXITCODE = $result.FailedCount
@@ -425,7 +421,7 @@ module Kitchen
         if !config[:shell].nil?
           config[:sudo] ? "sudo #{config[:shell]}" : "#{config[:shell]}"
         elsif windows_os?
-          'powershell'
+          "powershell"
         else
           config[:sudo] ? "sudo pwsh" : "pwsh"
         end
@@ -447,11 +443,10 @@ module Kitchen
           #{Util.outdent!(use_local_powershell_modules(code))}
           '@ | Set-Content -Path kitchen_cmd.ps1 -Encoding utf8 -Force -ErrorAction 'Stop'
           # create the modules folder, making sure it's done as current user (not root)
-          # 
+          #
           # Invoke the created kitchen_cmd.ps1 file using pwsh
           #{shell_cmd} ./kitchen_cmd.ps1
         PWSH
-        
         wrap_shell_code(Util.outdent!(my_command))
       end
 

--- a/lib/support/modules/PesterUtil/PesterUtil.psm1
+++ b/lib/support/modules/PesterUtil/PesterUtil.psm1
@@ -106,8 +106,9 @@ function Set-PSRepo {
         [Parameter(Mandatory)]
         $Repository
     )
+    
     if (-not (Get-Command Get-PSRepository) -and (Get-Command Get-PackageSource)) {
-        # Old version of PSGet do not have a *-PSrepository but have *-PackageSource instead.
+        # Old versions of PSGet do not have a *-PSrepository but have *-PackageSource instead.
         if (Get-PackageSource -Name $Repository.Name)  {
             Set-PackageSource @Repository
         }


### PR DESCRIPTION
Signed-off-by: Gael Colas <gaelcolas@synedgy.com>

This PR fixes Kitchen-Pester to work with 5.2+
while maintaining compatibility with 4.10.1.

It is more flexible to provide Pester parameters, and File download has been fixed (download test results).