### PR TITLE
(#69) Update Execution Policy to Process

### DIFF
--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -438,7 +438,9 @@ module Kitchen
           # Send the pwsh here string to the file kitchen_cmd.ps1
           @'
           try {
-              Set-ExecutionPolicy Unrestricted -force
+              if (@('Bypass', 'Unrestricted') -notcontains (Get-ExecutionPolicy)) {
+                  Set-ExecutionPolicy Unrestricted -Force -Scope Process
+              }
           }
           catch {
               $_ | Out-String | Write-Warning


### PR DESCRIPTION
# Description

Update Execution Policy to process scope will set it at the most specific scope it can be set at.

Only update Execution Policy if it needs to be updated.

## Issues Resolved

Fixes #69

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
