### PR TITLE
(#88) Add instance name replacement of destination

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -19,6 +19,8 @@ verifier:
   environment:
     API_KEY: Some key value
     PUSH_REPO: https://push.example.com
+  downloads:
+    "PesterTestResults.xml": "testresults/%{instance_name}/"
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,8 @@ verifier:
   environment:
     API_KEY: Some key value
     PUSH_REPO: https://push.example.com
+  downloads:
+    "PesterTestResults.xml": "testresults/%{instance_name}/"
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -143,7 +143,16 @@ This is necessary in certain cases, such as when `pwsh` is installed via `snap` 
 
 * `downloads`- map[string, string], defaults to `{"./PesterTestResults.xml" => "./testresults}"`.
 Files to download from SUT to local system, used to download the pester results localy.
-The key is the remote file (relative to verifier folder or absolute), the value is the directory (ends with / or \\) it should be saved to (relative to pwd or absolute).
+The key is the remote file to download, while the value is the destination.
+  * The source can:
+    * Be relative to the verifier folder (by default `$TEMP/verifier`)
+    * Be absolute on the system (e.g. `/var/tmp/file.zip` or `C:\\Windows\\Temp\\file.zip`)
+  * The destination can:
+    * Include `%{instance_name}` to indicate the Test Kitchen instance name
+    * Be a directory (ends in `/` or `\\`)
+    * Be relative to the Current Working Directory
+    * Be absolute
+
   ```yaml
   downloads:
       PesterTestResults.xml: "./output/testResults/"

--- a/TESTING.md
+++ b/TESTING.md
@@ -9,3 +9,4 @@ The general steps to test your changes:
 1. Build new gem: `chef gem build ./kitchen-pester.gemspec`
 1. Install built gem: `chef gem install ./kitchen-pester-<version>.gem`
 1. Test with `test-kitchen`: `kitchen test`
+1. Ensure that `PesterTestResults.xml` is created in `./testresults/default-windows-2016`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,6 +59,10 @@ stages:
             displayName: Run Tests
             env:
               SPEC_OPTS: --format progress
+          - task: PublishTestResults@2
+            inputs:
+              testResultsFormat: NUnit
+              testResultsFiles: 'testresults/**/PesterTestResults.xml'
       - job: Package
         dependsOn: Validate
         condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'), notIn(variables['Build.Reason'], 'PullRequest'))

--- a/lib/kitchen/verifier/pester.rb
+++ b/lib/kitchen/verifier/pester.rb
@@ -190,6 +190,7 @@ module Kitchen
         config[:downloads] = config[:downloads]
           .map do |source, destination|
             source = source.to_s
+            destination = destination.gsub("%{instance_name}", instance.name)
             info("  resolving remote source's absolute path.")
             unless source.match?('^/|^[a-zA-Z]:[\\/]') # is Absolute?
               info("  '#{source}' is a relative path, resolving to: #{File.join(config[:root_path], source)}")
@@ -203,7 +204,7 @@ module Kitchen
             if !File.directory?(File.dirname(destination))
               FileUtils.mkdir_p(File.dirname(destination))
             else
-              info("  Directory #{File.dirname(destination)} seem to exist.")
+              info("  Directory #{File.dirname(destination)} seems to exist.")
             end
 
             [ source, destination ]


### PR DESCRIPTION
# Description

Replaces `%{instance_name} in the destination with the instance name.

## Issues Resolved

Fixes #88 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
